### PR TITLE
whois bug

### DIFF
--- a/cogs/roles/roles_cog.py
+++ b/cogs/roles/roles_cog.py
@@ -113,6 +113,10 @@ class Roles(commands.Cog):
             return await context.channel.send(
                 f'{context.author.name}, role \'{arg[0]}\' does not exist')
 
+        if not utility.isGamesRole(role):
+            return await context.channel.send(
+                f'{context.author.name}, {role} is a restricted role')
+
         members = sorted(
             list(member.name for member in role.members), key=str.casefold)
 


### PR DESCRIPTION
Users were able to use .whois to look up who are in roles that are not managed by bots. e.g. "The High Table"

This PR adds a check that the role we're looking up is part of the roles list.