### PR TITLE
Fix member counts when listing games

### DIFF
--- a/charon.py
+++ b/charon.py
@@ -15,8 +15,12 @@ load_dotenv()
 TOKEN = os.getenv('DISCORD_TOKEN')
 COMMAND_PREFIX = os.getenv('COMMAND_PREFIX')
 
+intents = discord.Intents.default()  # All but the two privileged ones
+intents.members = True
 options = commands.DefaultHelpCommand(dm_help=True, no_category='Other')
-bot = commands.Bot(command_prefix=COMMAND_PREFIX, help_command=options)
+
+bot = commands.Bot(command_prefix=COMMAND_PREFIX, help_command=options,
+                   intents=intents)
 
 logging.basicConfig(level=logging.INFO)
 


### PR DESCRIPTION
Summary:
Follow the changes from Discord that implemented their privileged gateway intents. See: https://support-dev.discord.com/hc/en-us/articles/360056426994

We must now specify the intents when starting initializing the bot.